### PR TITLE
Fix break caused by pip-10 api change 

### DIFF
--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -13,6 +13,15 @@ try:
 except NameError:
     raw_input = input
 
+try:
+    # pip >= 10.0.0 hides main in pip._internal. We'll monkey patch what we need and hopefully this becomes available
+    # at some point.
+    from pip._internal import main, logger
+    pip.main = main
+    pip.logger = logger
+except ModuleNotFoundError:
+    pass
+
 
 WHITELIST = ['pip', 'setuptools']
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py26, py34, pypy
+envlist = py27, py26, py34, py36, pypy
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
Fixes #14 

This fixes `pip.main` not being found in pip >= 10.0.0, by using the `pip._internal` api. Not ideal, hopefully the pip project re exposes this in the future.