### PR TITLE
Handle VersionConflict and DistributionNotFound exceptions

### DIFF
--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -25,7 +25,14 @@ def autoremove(names, yes=False):
 
 
 def list_dead(names):
-    start = set(map(get_distribution, names))
+    start = set()
+    for name in names:
+        try:
+            start.add(get_distribution(name))
+        except DistributionNotFound:
+            print("%s is not an installed pip module, skipping" % name)
+        except VersionConflict:
+            print("%s is not the currently installed version, skipping" % name)
     graph = get_graph()
     dead = exclude_whitelist(find_all_dead(graph, start))
     for d in start:
@@ -105,7 +112,7 @@ def requires(dist):
             required.append(get_distribution(pkg.project_name))
         except DistributionNotFound as e:
             print(e.report())
-            print("Skipping %s", pkg.project_name)
+            print("Skipping %s" % pkg.project_name)
     return required
 
 

--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -30,9 +30,9 @@ def list_dead(names):
         try:
             start.add(get_distribution(name))
         except DistributionNotFound:
-            print("%s is not an installed pip module, skipping" % name)
+            print("%s is not an installed pip module, skipping" % name, file=sys.stderr)
         except VersionConflict:
-            print("%s is not the currently installed version, skipping" % name)
+            print("%s is not the currently installed version, skipping" % name, file=sys.stderr)
     graph = get_graph()
     dead = exclude_whitelist(find_all_dead(graph, start))
     for d in start:
@@ -107,12 +107,12 @@ def requires(dist):
         try:
             required.append(get_distribution(pkg))
         except VersionConflict as e:
-            print(e.report())
-            print("Redoing requirement with just package name...")
+            print(e.report(), file=sys.stderr)
+            print("Redoing requirement with just package name...", file=sys.stderr)
             required.append(get_distribution(pkg.project_name))
         except DistributionNotFound as e:
-            print(e.report())
-            print("Skipping %s" % pkg.project_name)
+            print(e.report(), file=sys.stderr)
+            print("Skipping %s" % pkg.project_name, file=sys.stderr)
     return required
 
 

--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import optparse
 
 import pip
-from pkg_resources import working_set, get_distribution
+from pkg_resources import working_set, get_distribution, VersionConflict, DistributionNotFound
 
 
 __version__ = '0.9.0'
@@ -95,7 +95,18 @@ def get_graph():
 
 
 def requires(dist):
-    return map(get_distribution, dist.requires())
+    required = []
+    for pkg in dist.requires():
+        try:
+            required.append(get_distribution(pkg))
+        except VersionConflict as e:
+            print(e.report())
+            print("Redoing requirement with just package name...")
+            required.append(get_distribution(pkg.project_name))
+        except DistributionNotFound as e:
+            print(e.report())
+            print("Skipping %s", pkg.project_name)
+    return required
 
 
 def main(argv=None):


### PR DESCRIPTION
These are due to packages being upgraded beyond what some depending package specifies (e.g. if you tend to do `pip list --outdated | xargs pip install --upgrade` or anything similar.)
To deal with this, we ignore version requirement if VersionConflict.

Not sure how we can end up in a DistributionNotFound scenario, but plenty of bug reports about it, so just ignoring those outright.

Fixes invl#7, invl#9, invl#10.