### PR TITLE
Show default help instead of exception, when no arguments are passed.

### DIFF
--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -102,6 +102,8 @@ def main(argv=None):
         list_leaves()
     elif opts.list:
         list_dead(args)
+    elif len(args) == 0:
+        parser.print_help()
     else:
         autoremove(args, yes=opts.yes)
 


### PR DESCRIPTION
Do something meaningful when run without arguments, instead of failure with an exception error.