### PR TITLE
Uninstall confirmation with Enter

### DIFF
--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -102,7 +102,7 @@ def fixed_point(f, x):
 
 
 def confirm(prompt):
-    return raw_input(prompt) == "y"
+    return raw_input(prompt).strip().lower() in ("y", "")
 
 
 def show_dist(dist):


### PR DESCRIPTION
Allow to confirm uninstall by pressing Enter instead of typing "y" (also allow capital y (Y)